### PR TITLE
Validate onChange

### DIFF
--- a/apps/formal-playground-web/src/examples/validate-on-change/README.md
+++ b/apps/formal-playground-web/src/examples/validate-on-change/README.md
@@ -1,0 +1,62 @@
+If you provided a **yup schema** to `config.schema`, **and validationType** `change` then the form will validate on the onChange event. Only the field being changed is validated.
+
+---
+
+> ℹ️ If the form is invalid, then `formal.isValid` will be set to `false`. Internally it keeps tracks of what fields have been validated with the onChange. Because required validation is only done on submit it also checks that required values are not `null`, `undefined`, or `''`.
+
+> ℹ️ The current field being validated is set to keep track of what field is being validated with `formal.validate`. It is cleared with `onBlur`.
+
+> ℹ️ If the field has an error, then `formal.getFieldProps(field)` will return `error = errorMsg`.
+
+> ℹ️ You can also get a field error message at `formal.errors[field]`.
+
+> ℹ️ If the validation failed and the current form values are the same as when the fail occurred, then `formal.getSubmitButtonProps()` will return `disabled = true`.
+
+> ℹ️ If the validation failed and the current form values are the same as when the fail occurred, then `formal.getSubmitButtonProps()` will return `disabled = true`.
+
+---
+
+> ✅ You can also manually validate the form by calling the imperative method `formal.validate()`.
+
+---
+
+```javascript
+import React from "react";
+import * as yup from "yup";
+import useFormal from "@kevinwolf/formal";
+
+const initialValues = {
+  firstName: "",
+  lastName: "",
+  email: ""
+};
+
+const schema = yup.object().shape({
+  firstName: yup.string().required(),
+  lastName: yup.string().required(),
+  email: yup
+    .string()
+    .email()
+    .required()
+});
+
+function ValidateOnSubmitExample() {
+  const formal = useFormal(initialValues, {
+    schema,
+    onSubmit: values => {
+      alert(JSON.stringify(values, null, 2));
+    },
+    validationType: "change"
+  });
+
+  return (
+    <form {...formal.getFormProps()}>
+      <input {...formal.getFieldProps("firstName")} type="text" />
+      <input {...formal.getFieldProps("lastName")} type="text" />
+      <input {...formal.getFieldProps("email")} type="text" />
+      <button {...formal.getResetButtonProps()}>Reset</button>
+      <button {...formal.getSubmitButtonProps()}>Submit</button>
+    </form>
+  );
+}
+```

--- a/apps/formal-playground-web/src/examples/validate-on-change/index.tsx
+++ b/apps/formal-playground-web/src/examples/validate-on-change/index.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import * as yup from 'yup'
+import useFormal from '@kevinwolf/formal-web'
+
+import Wrapper from '../../components/wrapper'
+import TextField from '../../components/text-field'
+import Toolbar from '../../components/toolbar'
+import Button from '../../components/button'
+
+const initialValues = {
+  firstName: '',
+  lastName: '',
+  email: '',
+}
+
+const schema = yup.object().shape({
+  firstName: yup.string().required(),
+  lastName: yup.string().required(),
+  email: yup
+    .string()
+    .email()
+    .required(),
+})
+
+export default function ValidateOnChangeExample(): JSX.Element {
+  const formal = useFormal(initialValues, {
+    schema,
+    onSubmit: values => {
+      alert(JSON.stringify(values, null, 2))
+    },
+    validationType: 'change',
+  })
+  return (
+    <Wrapper
+      title="Validate onChange"
+      subtitle="Synchronous validation"
+      debug={formal}
+    >
+      <form {...formal.getFormProps()}>
+        <TextField {...formal.getFieldProps('firstName')} label="First Name" />
+        <TextField {...formal.getFieldProps('lastName')} label="Last Name" />
+        <TextField {...formal.getFieldProps('email')} label="Email" />
+        <Toolbar>
+          <Button {...formal.getResetButtonProps()} variant="secondary">
+            Reset
+          </Button>
+          <Button
+            {...formal.getSubmitButtonProps()}>
+            Submit
+          </Button>
+        </Toolbar>
+      </form>
+    </Wrapper>
+  )
+}

--- a/apps/formal-playground-web/src/stories.tsx
+++ b/apps/formal-playground-web/src/stories.tsx
@@ -26,4 +26,5 @@ export default [
     'On Submit (async)',
     'validate-on-submit-async'
   ),
+  createStory('Examples/Validation', 'On Change', 'validate-on-change'),
 ]

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -22,6 +22,7 @@ Some of the props are just for react web or react native.
   - [FormalConfig](#formalconfig)
     - [schema](#schema)
     - [onSubmit](#onsubmit)
+    - [validationType](#validationtype)
   - [FormalState](#formalstate)
     - [isDirty](#isdirty)
     - [isValid](#isvalid)
@@ -36,6 +37,7 @@ Some of the props are just for react web or react native.
     - [validate](#validate)
     - [reset](#reset)
     - [submit](#submit)
+    - [blur](#blur)
     - [getFormProps](#getformprops)
     - [getFieldProps 💻](#getfieldprops-)
     - [getResetButtonProps](#getresetbuttonprops)
@@ -87,6 +89,7 @@ interface FormalConfig<Schema> {
     values: FormalValues,
     formal: FormalState<Schema>
   ) => void | Promise<any>;
+  validationType?: "change" | null;
 }
 ```
 
@@ -127,6 +130,10 @@ const formalConfig = {
 };
 ```
 
+#### validationType
+
+`validationType` is an optional prop to set validation to happen with the `onChange` event and `onSubmit`. The default is to only validate `onSubmit`.
+
 ### FormalState
 
 This is the state, callbacks, flags and _prop getters_ returned by **useFormal()** hook.
@@ -151,6 +158,7 @@ interface FormalState<Schema> {
   validate: () => void;
   reset: () => void;
   submit: () => void;
+  blur: (field: keyof Schema) => void;
 
   // Getters.
   getFormProps: () => FormalFormProps;
@@ -242,6 +250,14 @@ Programatically submit the form.
 
 ```typescript
 formal.submit();
+```
+
+#### blur
+
+Programatically call formal's `onBlur` cleanup.
+
+```typescript
+formal.blur("firstName");
 ```
 
 #### getFormProps

--- a/packages/formal-web/src/types.ts
+++ b/packages/formal-web/src/types.ts
@@ -19,15 +19,16 @@ export interface FormalWebFieldProps {
   name: string
   id: string
   onChange: (e: FormalWebTextFieldEvent) => void
+  onBlur: (e: FormalWebTextFieldEvent) => void
 }
 
 export interface FormalWebResetButtonProps {
-  type: string
+  type?: string
   onClick: () => void
 }
 
 export interface FormalWebSubmitButtonProps {
-  type: string
+  type?: string
 }
 
 export interface FormalWebState<Schema> extends FormalState<Schema> {

--- a/packages/formal-web/src/use-formal-web.ts
+++ b/packages/formal-web/src/use-formal-web.ts
@@ -27,6 +27,9 @@ export default function useFormalWeb<Schema>(
       onChange: (e: FormalWebTextFieldEvent) => {
         formal.change(field, e.target.value)
       },
+      onBlur: () => {
+        formal.blur(field)
+      },
     }),
     [formal]
   )

--- a/packages/formal/src/types.ts
+++ b/packages/formal/src/types.ts
@@ -2,7 +2,8 @@ import { Schema as YupSchema } from 'yup'
 
 export interface FormalConfig<Schema> {
   schema?: YupSchema<Schema>
-  onSubmit: (values: Schema) => void
+  onSubmit: (values: Schema) => void,
+  validationType?: 'change' | null
 }
 
 export type FormalErrors<Schema> = {
@@ -47,9 +48,10 @@ export interface FormalState<Schema> {
   change: (field: keyof Schema, value: any) => void
   setErrors: (errors: FormalErrors<Schema>) => void
   clearErrors: () => void
-  validate: () => void
+  validate: (field?: null| keyof Schema) => void
   reset: () => void
   submit: () => void
+  blur: (field: keyof Schema) => void;
 
   // Getters.
   getFieldProps: (field: keyof Schema) => FormalFieldProps

--- a/packages/formal/src/use-formal.ts
+++ b/packages/formal/src/use-formal.ts
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from 'react'
+import { useEffect, useState, useMemo, useCallback } from 'react'
 import isEqual from 'react-fast-compare'
 
 import { FormalConfig, FormalState, FormalErrors } from './types'
@@ -67,6 +67,12 @@ export default function useFormal<Schema>(
       }
     })
   }, [schema, values, clearErrors, setErrors])
+  
+
+  useEffect(() => {
+      validate()
+    }, [values, validate]
+  )
 
   const reset = useCallback(() => {
     setValues(lastValues)

--- a/packages/formal/src/use-formal.ts
+++ b/packages/formal/src/use-formal.ts
@@ -6,14 +6,17 @@ import {
   objectIsEmpty,
   schemaHasAsyncValidation,
   formatYupErrors,
+  equalSets,
+  checkRequired,
 } from './utils'
 
 export default function useFormal<Schema>(
   initialValues: Schema,
-  { schema, onSubmit }: FormalConfig<Schema>
+  { schema, onSubmit, validationType = null }: FormalConfig<Schema>,
 ): FormalState<Schema> {
   const [lastValues, setLastValues] = useState<Schema>(initialValues)
   const [values, setValues] = useState<Schema>(initialValues)
+  const [validatedFields, setValidatedFields] = useState<{validated: string[], activeField:keyof Schema | null}>({validated: [], activeField: null})
 
   const [errors, setErrors] = useState<FormalErrors<Schema>>({})
 
@@ -26,23 +29,34 @@ export default function useFormal<Schema>(
     values,
   ])
 
-  const isValid = useMemo(() => !isDirty || objectIsEmpty(errors), [
-    errors,
-    isDirty,
-  ])
+  const isValid = useMemo(() => {
+    const { validated } = validatedFields
+    // @ts-ignore
+    return !!(!isDirty || objectIsEmpty(errors)) && (!schema || (schema && equalSets(new Set(Object.keys(schema.fields)), new Set(validated)) && checkRequired(schema, values) ))
+  }, [errors, isDirty, schema, validatedFields, values])
 
   const change = useCallback(
     (field: keyof Schema, value: any): void => {
       setValues((prevValues: Schema) => ({ ...prevValues, [field]: value }))
+      // @ts-ignore
+      setValidatedFields((prevValues: {validated: string[], activeField: keyof Schema | null}) => ({validated: [...prevValues.validated, field], activeField: field}))
     },
     []
   )
+  
+  
+  useEffect(() => {
+    const { activeField } = validatedFields
+    if (validationType === 'change' && activeField && typeof values === 'object' && values[activeField]) {
+      validate(activeField)
+    }
+  }, [validate, validatedFields, validatedFields.activeField, validationType, values])
 
   const clearErrors = useCallback(() => {
     setErrors({})
   }, [])
 
-  const validate = useCallback(() => {
+  const validate = useCallback((field: null | keyof Schema = null) => {
     if (!schema) {
       throw new Error(
         'You cannot call validate if you have not provided any schema.'
@@ -57,22 +71,20 @@ export default function useFormal<Schema>(
 
         clearErrors()
         if (isAsync) setIsValidating(true)
-        await schema[validationMethod](values, { abortEarly: false })
+        if (field != null && typeof field === 'string') {
+          await schema.validateAt(field, values)
+        } else {
+          await schema[validationMethod](values, { abortEarly: false })
+        }
         resolve()
       } catch (error) {
-        setErrors(formatYupErrors<Schema>(error))
+        setErrors(formatYupErrors<Schema>(error, field))
         reject()
       } finally {
         if (isAsync) setIsValidating(false)
       }
     })
   }, [schema, values, clearErrors, setErrors])
-  
-
-  useEffect(() => {
-      validate()
-    }, [values, validate]
-  )
 
   const reset = useCallback(() => {
     setValues(lastValues)
@@ -120,6 +132,10 @@ export default function useFormal<Schema>(
     [errors, isDirty, isSubmitted, isSubmitting, isValidating]
   )
 
+  const blur = useCallback( () => {
+    setValidatedFields((prevValues: {validated: string[], activeField: keyof Schema | null}) => ({validated: prevValues.validated, activeField: null}))
+  }, [])
+
   return {
     isDirty,
     isValid,
@@ -137,5 +153,6 @@ export default function useFormal<Schema>(
     getFieldProps,
     getResetButtonProps,
     getSubmitButtonProps,
+    blur,
   }
 }

--- a/packages/formal/src/utils.ts
+++ b/packages/formal/src/utils.ts
@@ -1,15 +1,20 @@
-/* eslint-disable no-restricted-syntax, @typescript-eslint/no-object-literal-type-assertion, no-prototype-builtins */
+/* eslint-disable no-restricted-syntax, @typescript-eslint/no-object-literal-type-assertion, no-prototype-builtins, no-underscore-dangle */
 import { Schema as YupSchema } from 'yup'
 
 import { FormalErrors } from './types'
 
-export function formatYupErrors<Values>(yupError: any): FormalErrors<Values> {
+export function formatYupErrors<Values>(yupError: any, field: null | keyof Values = null): FormalErrors<Values> {
   const errors: any = {} as FormalErrors<Values>
-
   if(typeof yupError === 'object' && yupError.hasOwnProperty('inner')){
-    for (const err of yupError.inner) {
-      if (!errors[err.path]) {
-        errors[err.path] = err.message
+    // Setting a singe field
+    if (field && yupError.path === field && yupError.message) {
+      errors[field] = yupError.message
+    // Setting all fields
+    } else {
+      for (const err of yupError.inner) {
+        if (!errors[err.path]) {
+          errors[err.path] = err.message
+        }
       }
     }
   }
@@ -36,4 +41,25 @@ export function schemaHasAsyncValidation<Schema>(
   }
 
   return false
+}
+
+export function equalSets(set1: Set<string>, set2: Set<string>) {
+   if (set1.size !== set2.size) return false
+    // @ts-ignore
+    for (const item of set1) if (!set2.has(item)) return false
+    return true
+}
+
+
+export function checkRequired<Schema>(schema: YupSchema<Schema>, values: Schema) {
+  if (schema && schema.hasOwnProperty('fields')) {
+    // @ts-ignore
+    for (const field in schema.fields) {
+      // @ts-ignore
+      if (schema.fields[field]._exclusive.required && (values[field] === undefined || values[field] === '')) {
+        return false
+      }
+    }
+  }
+  return true
 }


### PR DESCRIPTION
# Whats new?

Adds an effect to validate onChange

## Issue link

#15 onChange validation

Closes #0

## Notes
This validates all of the fields in an onChange. It couldn't easily find a way to validate on a per field basis because 1) Calling validate in `change` after `setValues` doesn't validate the updated presumably because validate is called before the update completes. 2) I thought to loop through the schema fields to set an effect for each value but this was difficult because you can't call useEffect in a callback.

Should a flag to set this effect be added to the config?
