### PR TITLE
Add param enableReinitialize to useFormal

### DIFF
--- a/packages/formal-native/src/use-formal-native.ts
+++ b/packages/formal-native/src/use-formal-native.ts
@@ -5,9 +5,10 @@ import { FormalNativeState } from './types'
 
 export default function useFormalNative<Schema>(
   initialValues: Schema,
-  config: FormalConfig<Schema>
+  config: FormalConfig<Schema>,
+  enableReinitialize = false,
 ): FormalNativeState<Schema> {
-  const formal = useFormal(initialValues, config)
+  const formal = useFormal(initialValues, config, enableReinitialize)
 
   const getFormProps = useCallback(() => {
     throw new Error('formal.getFormProps() is not supported on React Native')

--- a/packages/formal-web/src/use-formal-web.ts
+++ b/packages/formal-web/src/use-formal-web.ts
@@ -5,9 +5,10 @@ import { FormalWebState, FormalWebTextFieldEvent } from './types'
 
 export default function useFormalWeb<Schema>(
   initialValues: Schema,
-  config: FormalConfig<Schema>
+  config: FormalConfig<Schema>,
+  enableReinitialize = false,
 ): FormalWebState<Schema> {
-  const formal = useFormal(initialValues, config)
+  const formal = useFormal(initialValues, config, enableReinitialize)
 
   const getFormProps = useCallback(
     () => ({


### PR DESCRIPTION
# Whats new?

Inspired from Formik. "Default is false. Control whether _Formal_ should reset the form if initialValues changes (using deep equality)."

## Notes

Helpful in our case when we have a page that is pushed information from a webSocket every n seconds, where we want a simple input form to reflect the current state of things. So if boxes per hour goes from 40 to 60, we want 60 to be the default value instead of staying with 40 until refresh.

This should probably follow: https://github.com/iamkevinwolf/formal/pull/112
